### PR TITLE
feat: add semver release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Vet
         run: go vet ./...
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Build
         env:
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v[0-9]*.[0-9]*.[0-9]*"
 
 jobs:
 
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Vet
         run: go vet ./...
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Build
         env:
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Build
         env:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered by `v*.*.*` tags
- Runs the same test → build-arm64 → build-amd64 → release pipeline as CI
- Produces arm64, amd64, and universal (lipo) binaries attached to a versioned GitHub release
- Uses `generate_release_notes: true` to auto-populate release notes from merged PRs/commits

## Usage

After merging, create a release by pushing a semver tag:

```sh
git tag v1.0.0
git push origin v1.0.0
```

## Test plan

- [ ] Merge PR
- [ ] Push a `v*.*.*` tag and verify the Actions workflow runs
- [ ] Confirm a non-pre-release is created with all three binaries attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)