### PR TITLE
fix: replace deprecated macos-13 runner with cross-compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     name: Build (amd64)
     needs: test
     if: github.event_name == 'push'
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -77,6 +77,7 @@ jobs:
         env:
           GOARCH: amd64
           CGO_ENABLED: "1"
+          SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         run: go build -ldflags="-s -w" -o muzak-darwin-amd64 .
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
   build-amd64:
     name: Build (amd64)
     needs: test
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -71,6 +71,7 @@ jobs:
         env:
           GOARCH: amd64
           CGO_ENABLED: "1"
+          SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         run: go build -ldflags="-s -w" -o muzak-darwin-amd64 .
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary

- `macos-13` (Intel) runner is no longer supported on GitHub Actions, causing `build-amd64` to fail immediately
- Switches `build-amd64` to `macos-latest` (arm64) in both `ci.yml` and `release.yml`
- Sets `SDKROOT` to the macOS universal SDK path so CGo can cross-compile for `amd64` from an arm64 host

## Test plan

- [ ] Verify `Build (amd64)` job completes successfully
- [ ] Verify the universal binary produced by `lipo` contains both `arm64` and `x86_64` slices

🤖 Generated with [Claude Code](https://claude.com/claude-code)