### PR TITLE
fix: use gh auth setup-git for tap push authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,11 +145,11 @@ jobs:
           echo "amd64=$(sha256sum muzak-darwin-amd64.tar.gz | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Clone tap repo
-        uses: actions/checkout@v4
-        with:
-          repository: ronelliott/homebrew-muzak
-          token: ${{ secrets.TAP_GITHUB_TOKEN }}
-          path: tap
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          gh auth setup-git
+          git clone https://github.com/ronelliott/homebrew-muzak.git tap
 
       - name: Write formula
         env:
@@ -189,6 +189,8 @@ jobs:
           EOF
 
       - name: Commit and push
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
           cd tap
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

Replaces the `actions/checkout` token approach with `gh auth setup-git`, which configures a credential helper that reads `GH_TOKEN` from the environment at runtime — the token is never stored in `.git/config` or embedded in URLs.

- `Clone tap repo` step: sets `GH_TOKEN`, calls `gh auth setup-git`, then clones via plain HTTPS
- `Commit and push` step: sets `GH_TOKEN` so the credential helper can authenticate the push

## Test plan

- [ ] Merge and tag a new release
- [ ] Verify `update-tap` job pushes the updated formula to `ronelliott/homebrew-muzak`

🤖 Generated with [Claude Code](https://claude.com/claude-code)