### PR TITLE
feat: add prev/next controls and playback status icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Playback starts automatically with the first track found.
 | Key | Action |
 |-----|--------|
 | `p` | Pause / play |
+| `,` | Previous track |
+| `.` | Next track |
 | `[` | Rewind 10 seconds |
 | `]` | Fast-forward 10 seconds |
 | `+` | Volume up |
@@ -81,6 +83,7 @@ The last 15 played tracks are shown above the now-playing bar, newest at the bot
 ## Status indicators
 
 The now-playing bar shows:
+- `▶` when playing, `⏸` when paused, `⏹` when the playlist has ended
 - `[S]` when shuffle is active
 - `[R]` when repeat is active
 - Current position and total duration

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -78,6 +78,24 @@ func (p *Playlist) SetFirst() *library.Track {
 	return p.Current()
 }
 
+// Prev moves to the previous track. When already at the first track and repeat
+// is off, it stays on the first track. With repeat on it wraps to the last.
+func (p *Playlist) Prev() *library.Track {
+	if len(p.order) == 0 {
+		return nil
+	}
+	prev := p.cursor - 1
+	if prev < 0 {
+		if p.repeat {
+			prev = len(p.order) - 1
+		} else {
+			prev = 0
+		}
+	}
+	p.SetCursor(prev)
+	return p.Current()
+}
+
 // Next advances to the next track. Returns nil if the playlist is exhausted
 // and repeat is off.
 func (p *Playlist) Next() *library.Track {

--- a/playlist/playlist.go
+++ b/playlist/playlist.go
@@ -79,17 +79,21 @@ func (p *Playlist) SetFirst() *library.Track {
 }
 
 // Prev moves to the previous track. When already at the first track and repeat
-// is off, it stays on the first track. With repeat on it wraps to the last.
+// is off, it stays on the first track. With repeat on it wraps to the last,
+// reshuffling first when shuffle is also enabled (mirrors Next() behaviour).
 func (p *Playlist) Prev() *library.Track {
 	if len(p.order) == 0 {
 		return nil
 	}
 	prev := p.cursor - 1
 	if prev < 0 {
-		if p.repeat {
-			prev = len(p.order) - 1
-		} else {
+		if !p.repeat {
 			prev = 0
+		} else {
+			if p.shuffle {
+				p.applyShuffleAround(-1)
+			}
+			prev = len(p.order) - 1
 		}
 	}
 	p.SetCursor(prev)

--- a/playlist/playlist_test.go
+++ b/playlist/playlist_test.go
@@ -118,6 +118,74 @@ func TestNext_WrapsAtEndWithRepeat(t *testing.T) {
 	}
 }
 
+// ─── Prev ─────────────────────────────────────────────────────────────────────
+
+func TestPrev_MovesBackFromMiddle(t *testing.T) {
+	tracks := makeTracks(3)
+	p := New(tracks)
+	p.SetFirst()
+	p.Next() // cursor = 1
+
+	got := p.Prev()
+	if got != tracks[0] {
+		t.Errorf("Prev() returned wrong track")
+	}
+	if p.cursor != 0 {
+		t.Errorf("cursor = %d, want 0", p.cursor)
+	}
+}
+
+func TestPrev_ClampsAtFirstTrackWithoutRepeat(t *testing.T) {
+	tracks := makeTracks(3)
+	p := New(tracks)
+	p.SetFirst() // cursor = 0
+
+	got := p.Prev()
+	if got != tracks[0] {
+		t.Errorf("Prev() at first track without repeat should return first track")
+	}
+	if p.cursor != 0 {
+		t.Errorf("cursor = %d, want 0", p.cursor)
+	}
+}
+
+func TestPrev_WrapsToLastWithRepeat(t *testing.T) {
+	tracks := makeTracks(3)
+	p := New(tracks)
+	p.SetRepeat(true)
+	p.SetFirst() // cursor = 0
+
+	got := p.Prev()
+	if got != tracks[2] {
+		t.Errorf("Prev() with repeat should wrap to last track")
+	}
+	if p.cursor != 2 {
+		t.Errorf("cursor after wrap = %d, want 2", p.cursor)
+	}
+}
+
+func TestPrev_ShuffleRepeat_ReshufflesOnWrap(t *testing.T) {
+	p := New(makeTracks(8))
+	p.SetRepeat(true)
+	p.SetShuffle(true)
+	p.SetFirst() // cursor = 0
+	orderBefore := orderOf(p)
+
+	p.Prev() // should wrap and reshuffle
+
+	orderAfter := orderOf(p)
+	same := true
+	for i := range orderBefore {
+		if orderBefore[i] != orderAfter[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Error("Prev() with shuffle+repeat should reshuffle on wrap (astronomically unlikely to produce identical order)")
+	}
+}
+
 // ─── JumpToTrack ──────────────────────────────────────────────────────────────
 
 func TestJumpToTrack_FindsTrack(t *testing.T) {

--- a/ui/keys.go
+++ b/ui/keys.go
@@ -2,6 +2,8 @@ package ui
 
 const (
 	keyPause   = "p"
+	keyPrev    = ","
+	keyNext    = "."
 	keyRewind  = "["
 	keyForward = "]"
 	keyShuffle = "s"
@@ -12,4 +14,4 @@ const (
 	keyQuit    = "q"
 )
 
-const helpLine = "p=pause/play  [/]=rew/fwd  s=shuffle  r=repeat  +/-=vol  l=library  \u2191\u2193=nav  \u21b5=play  q=quit"
+const helpLine = "p=pause/play  ,/.=prev/next  [/]=rew/fwd  s=shuffle  r=repeat  +/-=vol  l=library  \u2191\u2193=nav  \u21b5=play  q=quit"

--- a/ui/model.go
+++ b/ui/model.go
@@ -200,6 +200,17 @@ func (m *Model) handlePlayerKey(key string) (tea.Model, tea.Cmd) {
 	history := m.playlist.History()
 
 	switch key {
+	case keyPrev:
+		m.playlist.Prev()
+		return m, m.cmdLoadAndPlay()
+
+	case keyNext:
+		next := m.playlist.Next()
+		if next == nil {
+			return m, nil
+		}
+		return m, m.cmdLoadAndPlay()
+
 	case keyRewind:
 		if m.current != nil {
 			target := m.position - seekStep

--- a/ui/view.go
+++ b/ui/view.go
@@ -13,6 +13,7 @@ import (
 // ─── styles ──────────────────────────────────────────────────────────────────
 
 var (
+	styleStatus     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("226"))
 	styleNowPlaying = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("86"))
 	stylePaused     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
 	styleSelected   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("213"))
@@ -153,10 +154,14 @@ func (m *Model) renderNowPlaying() string {
 	meta := styleControls.Render(fmt.Sprintf("  %s  Vol:%d%%", progress, vol)) + flags
 
 	name := truncate(track.DisplayName(), m.width/2)
-	if m.current != nil && m.current.IsPlaying() {
-		return styleNowPlaying.Render("Now Playing: "+name) + meta
+	switch {
+	case m.current != nil && m.current.IsPlaying():
+		return styleStatus.Render("▶") + " " + styleNowPlaying.Render(name) + meta
+	case m.current == nil:
+		return styleStatus.Render("⏹") + " " + stylePaused.Render(name) + meta // end of playlist
+	default:
+		return styleStatus.Render("⏸") + " " + stylePaused.Render(name) + meta
 	}
-	return stylePaused.Render("Paused: "+name) + meta
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `,` / `.` keybindings for previous and next track
- Add `Prev()` to the playlist package (mirrors `Next()`, wraps with repeat on)
- Replace `Now Playing:` / `Paused:` text labels with `▶` / `⏸` / `⏹` icons
- Status icon rendered in bright yellow, distinct from the track title colour
- Explicitly handle end-of-playlist state with `⏹`
- README updated with new controls and status icon descriptions

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)