### PR TITLE
feat: fix library filter input and rebind library toggle to esc

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,14 @@ Playback starts automatically with the first track found.
 | `-` | Volume down |
 | `s` | Toggle shuffle |
 | `r` | Toggle repeat |
-| `l` | Open / close library |
+| `Esc` | Open / close library |
 | `↑` / `↓` | Navigate history or library |
 | `Enter` | Play from selected track |
-| `Esc` | Close library |
 | `q` | Quit |
 
 ## Library overlay
 
-Press `l` to open the library overlay, which lists all discovered tracks. Type to filter by artist or title. Press `Enter` to start playing from the selected track. Press `Esc` or `l` again to return to the history view.
+Press `Esc` to open the library overlay, which lists all discovered tracks. Type to filter by artist or title. Press `Enter` to start playing from the selected track. Press `Esc` again to return to the history view.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ Playback starts automatically with the first track found.
 | `Esc` | Open / close library |
 | `↑` / `↓` | Navigate history or library |
 | `Enter` | Play from selected track |
-| `q` | Quit |
+| `q` | Quit (player view only) |
+| `ctrl+c` | Quit (anywhere) |
 
 ## Library overlay
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,7 +51,8 @@ Controls:
   esc          Toggle library overlay
   ↑ / ↓        Navigate
   ↵            Play selected
-  q / ctrl+c   Quit`),
+  q            Quit (player view)
+  ctrl+c       Quit (anywhere)`),
 		snek.WithVersion(getVersion()),
 		snek.WithSimpleRunE(runPlay),
 		snek.WithSubCommandGenerator(cmdlibrary.NewCommand),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,7 +48,7 @@ Controls:
   s            Shuffle
   r            Repeat
   + / -        Volume up / down
-  l / esc      Toggle library overlay
+  esc          Toggle library overlay
   ↑ / ↓        Navigate
   ↵            Play selected
   q / ctrl+c   Quit`),

--- a/ui/keys.go
+++ b/ui/keys.go
@@ -10,8 +10,8 @@ const (
 	keyRepeat  = "r"
 	keyVolUp   = "+"
 	keyVolDown = "-"
-	keyLibrary = "l"
+	keyLibrary = "esc"
 	keyQuit    = "q"
 )
 
-const helpLine = "p=pause/play  ,/.=prev/next  [/]=rew/fwd  s=shuffle  r=repeat  +/-=vol  l=library  \u2191\u2193=nav  \u21b5=play  q=quit"
+const helpLine = "p=pause/play  ,/.=prev/next  [/]=rew/fwd  s=shuffle  r=repeat  +/-=vol  esc=library  \u2191\u2193=nav  \u21b5=play  q=quit"

--- a/ui/keys.go
+++ b/ui/keys.go
@@ -15,3 +15,4 @@ const (
 )
 
 const helpLine = "p=pause/play  ,/.=prev/next  [/]=rew/fwd  s=shuffle  r=repeat  +/-=vol  esc=library  \u2191\u2193=nav  \u21b5=play  q=quit"
+const helpLineLibrary = "ctrl+c=quit"

--- a/ui/model.go
+++ b/ui/model.go
@@ -146,48 +146,60 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	// Keys that work in any mode.
-	switch key {
-	case "ctrl+c", keyQuit:
+	// ctrl+c always quits, even while typing in the library filter.
+	if key == "ctrl+c" {
 		if m.current != nil {
 			m.backend.Stop()
 			m.current.Close()
 		}
 		return m, tea.Quit
+	}
 
-	case keyPause:
-		if m.current != nil {
-			if m.current.IsPlaying() {
-				m.current.Pause()
-			} else {
-				m.current.Play()
+	// Player control shortcuts are suppressed while the library filter is active
+	// so that typed characters go to the search box instead.
+	if m.mode != modeLibrary {
+		switch key {
+		case keyQuit:
+			if m.current != nil {
+				m.backend.Stop()
+				m.current.Close()
 			}
+			return m, tea.Quit
+
+		case keyPause:
+			if m.current != nil {
+				if m.current.IsPlaying() {
+					m.current.Pause()
+				} else {
+					m.current.Play()
+				}
+			}
+			return m, nil
+
+		case keyVolUp:
+			m.volume = clamp(m.volume+volumeStep, 0, 1)
+			if m.current != nil {
+				m.current.SetVolume(m.volume)
+			}
+			settings.Save(settings.Settings{Volume: m.volume})
+			return m, nil
+
+		case keyVolDown:
+			m.volume = clamp(m.volume-volumeStep, 0, 1)
+			if m.current != nil {
+				m.current.SetVolume(m.volume)
+			}
+			settings.Save(settings.Settings{Volume: m.volume})
+			return m, nil
+
+		case keyShuffle:
+			m.playlist.SetShuffle(!m.playlist.Shuffle())
+			return m, nil
+
+		case keyRepeat:
+			m.playlist.SetRepeat(!m.playlist.Repeat())
+			return m, nil
 		}
-		return m, nil
-
-	case keyVolUp:
-		m.volume = clamp(m.volume+volumeStep, 0, 1)
-		if m.current != nil {
-			m.current.SetVolume(m.volume)
-		}
-		settings.Save(settings.Settings{Volume: m.volume})
-		return m, nil
-
-	case keyVolDown:
-		m.volume = clamp(m.volume-volumeStep, 0, 1)
-		if m.current != nil {
-			m.current.SetVolume(m.volume)
-		}
-		settings.Save(settings.Settings{Volume: m.volume})
-		return m, nil
-
-	case keyShuffle:
-		m.playlist.SetShuffle(!m.playlist.Shuffle())
-		return m, nil
-
-	case keyRepeat:
-		m.playlist.SetRepeat(!m.playlist.Repeat())
-		return m, nil
 	}
 
 	if m.mode == modeLibrary {
@@ -260,7 +272,7 @@ func (m *Model) handleLibraryKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	visLines := m.libraryVisibleLines()
 
 	switch {
-	case key == "esc" || key == keyLibrary:
+	case key == keyLibrary:
 		m.mode = modePlayer
 
 	case key == "up":
@@ -298,6 +310,10 @@ func (m *Model) handleLibraryKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.libSearch = string(r[:len(r)-1])
 			m.updateLibFilter()
 		}
+
+	case msg.Type == tea.KeySpace:
+		m.libSearch += " "
+		m.updateLibFilter()
 
 	case msg.Type == tea.KeyRunes:
 		m.libSearch += string(msg.Runes)

--- a/ui/model.go
+++ b/ui/model.go
@@ -148,10 +148,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// ctrl+c always quits, even while typing in the library filter.
 	if key == "ctrl+c" {
-		if m.current != nil {
-			m.backend.Stop()
-			m.current.Close()
-		}
+		m.stopAndClose()
 		return m, tea.Quit
 	}
 
@@ -160,10 +157,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.mode != modeLibrary {
 		switch key {
 		case keyQuit:
-			if m.current != nil {
-				m.backend.Stop()
-				m.current.Close()
-			}
+			m.stopAndClose()
 			return m, tea.Quit
 
 		case keyPause:
@@ -383,6 +377,13 @@ func (m *Model) cmdLoadAndPlay() tea.Cmd {
 	return func() tea.Msg {
 		<-pb.Done()
 		return trackDoneMsg{id: id}
+	}
+}
+
+func (m *Model) stopAndClose() {
+	if m.current != nil {
+		m.backend.Stop()
+		m.current.Close()
 	}
 }
 

--- a/ui/model.go
+++ b/ui/model.go
@@ -382,8 +382,12 @@ func (m *Model) cmdLoadAndPlay() tea.Cmd {
 
 func (m *Model) stopAndClose() {
 	if m.current != nil {
+		m.trackID++ // invalidate any in-flight trackDoneMsg
 		m.backend.Stop()
 		m.current.Close()
+		m.current = nil
+		m.position = 0
+		m.duration = 0
 	}
 }
 

--- a/ui/view.go
+++ b/ui/view.go
@@ -130,7 +130,11 @@ func (m *Model) renderLibrary(sb *strings.Builder) {
 // ─── controls & now-playing ───────────────────────────────────────────────────
 
 func (m *Model) renderControls() string {
-	return styleControls.Render(truncate(helpLine, m.width))
+	line := helpLine
+	if m.mode == modeLibrary {
+		line = helpLineLibrary
+	}
+	return styleControls.Render(truncate(line, m.width))
 }
 
 func (m *Model) renderNowPlaying() string {


### PR DESCRIPTION
## Summary

- Player control shortcuts (`r`, `p`, `s`, `q`, `+`, `-`) were intercepted before mode dispatch, making those letters untypeable in the library filter box — shortcuts are now suppressed while the library is open (`ctrl+c` remains a universal quit)
- Space character was not appendable to the filter query (BubbleTea treats it as `KeySpace`, not `KeyRunes`) — added explicit handling
- Library toggle rebound from `l` to `esc`

## Test plan

- [ ] Open library with `esc`, type `r`, `p`, `s`, `q` — characters appear in filter, playback unaffected
- [ ] Type a space in the filter — works correctly
- [ ] Press `esc` again — library closes
- [ ] Outside library, `r`/`p`/`s`/`q`/`+`/`-` still function as player controls
- [ ] `ctrl+c` quits from both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)