### PR TITLE
feat: switch tap update to repository_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,98 +295,19 @@ jobs:
             muzak-windows-amd64.zip
             muzak-windows-arm64.zip
 
-  # ── update-tap ──────────────────────────────────────────────────────────────
-  # Computes SHA256 of macOS/Linux tarballs and pushes an updated formula.
-  # Windows is not distributed via Homebrew.
+  # ── notify-tap ──────────────────────────────────────────────────────────────
+  # Fires a repository_dispatch to homebrew-muzak, which owns the formula
+  # update logic in its own workflow.
 
-  update-tap:
-    name: Update Homebrew Tap
+  notify-tap:
+    name: Notify Homebrew Tap
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - name: Download tarballs
-        run: |
-          for target in darwin-arm64 darwin-amd64 linux-amd64 linux-arm64; do
-            curl --retry 5 --retry-delay 5 -fsSL \
-              "https://github.com/ronelliott/muzak/releases/download/${{ github.ref_name }}/muzak-${target}.tar.gz" \
-              -o "muzak-${target}.tar.gz"
-          done
-
-      - name: Compute SHA256s
-        id: sha
-        run: |
-          echo "darwin_arm64=$(sha256sum muzak-darwin-arm64.tar.gz | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-          echo "darwin_amd64=$(sha256sum muzak-darwin-amd64.tar.gz | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-          echo "linux_amd64=$(sha256sum muzak-linux-amd64.tar.gz | awk '{print $1}')"   >> "$GITHUB_OUTPUT"
-          echo "linux_arm64=$(sha256sum muzak-linux-arm64.tar.gz | awk '{print $1}')"   >> "$GITHUB_OUTPUT"
-
-      - name: Clone tap repo
-        uses: actions/checkout@v4
-        with:
-          repository: ronelliott/homebrew-muzak
-          token: ${{ secrets.TAP_GITHUB_TOKEN }}
-          path: tap
-
-      - name: Write formula
-        env:
-          VERSION: ${{ github.ref_name }}
-          SHA_DARWIN_ARM64: ${{ steps.sha.outputs.darwin_arm64 }}
-          SHA_DARWIN_AMD64: ${{ steps.sha.outputs.darwin_amd64 }}
-          SHA_LINUX_AMD64: ${{ steps.sha.outputs.linux_amd64 }}
-          SHA_LINUX_ARM64: ${{ steps.sha.outputs.linux_arm64 }}
-        run: |
-          VERSION_NUM="${VERSION#v}"
-          cat > tap/Formula/muzak.rb <<EOF
-          class Muzak < Formula
-            desc "Minimalist terminal-based music player"
-            homepage "https://github.com/ronelliott/muzak"
-            version "${VERSION_NUM}"
-            license "MIT"
-
-            on_macos do
-              on_arm do
-                url "https://github.com/ronelliott/muzak/releases/download/${VERSION}/muzak-darwin-arm64.tar.gz"
-                sha256 "${SHA_DARWIN_ARM64}"
-              end
-
-              on_intel do
-                url "https://github.com/ronelliott/muzak/releases/download/${VERSION}/muzak-darwin-amd64.tar.gz"
-                sha256 "${SHA_DARWIN_AMD64}"
-              end
-            end
-
-            on_linux do
-              depends_on "alsa-lib"
-
-              on_intel do
-                url "https://github.com/ronelliott/muzak/releases/download/${VERSION}/muzak-linux-amd64.tar.gz"
-                sha256 "${SHA_LINUX_AMD64}"
-              end
-
-              on_arm do
-                url "https://github.com/ronelliott/muzak/releases/download/${VERSION}/muzak-linux-arm64.tar.gz"
-                sha256 "${SHA_LINUX_ARM64}"
-              end
-            end
-
-            def install
-              bin.install "muzak"
-              chmod 0555, bin/"muzak"
-            end
-
-            test do
-              assert_match version.to_s, shell_output("#{bin}/muzak --version")
-            end
-          end
-          EOF
-
-      - name: Commit and push
+      - name: Dispatch to homebrew-muzak
         env:
           GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
-          cd tap
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/muzak.rb
-          git diff --staged --quiet || git commit -m "chore: update muzak to ${{ github.ref_name }}"
-          git push
+          gh api repos/ronelliott/homebrew-muzak/dispatches \
+            -f event_type=muzak-release \
+            -f "client_payload[tag]=${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,6 +298,9 @@ jobs:
   # ── notify-tap ──────────────────────────────────────────────────────────────
   # Fires a repository_dispatch to homebrew-muzak, which owns the formula
   # update logic in its own workflow.
+  # TAP_GITHUB_TOKEN requirements:
+  #   - Fine-grained PAT: Contents: write on ronelliott/homebrew-muzak
+  #   - Classic PAT: repo scope
 
   notify-tap:
     name: Notify Homebrew Tap


### PR DESCRIPTION
## Summary

- Replaces the `update-tap` job (which cloned homebrew-muzak and pushed the formula directly) with a lean `notify-tap` job that fires a `repository_dispatch` event
- The tap repo now owns its formula update logic in its own workflow
- `TAP_GITHUB_TOKEN` requires **Contents: write** on `homebrew-muzak` for a fine-grained PAT, or **repo** scope for a classic PAT

## Test plan

- [ ] Tag a release and confirm `notify-tap` job completes successfully
- [ ] Confirm the `muzak-release` dispatch triggers the `update-formula` workflow in `ronelliott/homebrew-muzak`

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.