### PR TITLE
ci: retarget Homebrew dispatch to homebrew-public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,10 +296,10 @@ jobs:
             muzak-windows-arm64.zip
 
   # ── notify-tap ──────────────────────────────────────────────────────────────
-  # Fires a repository_dispatch to homebrew-muzak, which owns the formula
+  # Fires a repository_dispatch to homebrew-public, which owns the formula
   # update logic in its own workflow.
   # TAP_GITHUB_TOKEN requirements:
-  #   - Fine-grained PAT: Contents: write on ronelliott/homebrew-muzak
+  #   - Fine-grained PAT: Contents: write on ronelliott/homebrew-public
   #   - Classic PAT: repo scope
 
   notify-tap:
@@ -307,10 +307,10 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch to homebrew-muzak
+      - name: Dispatch to homebrew-public
         env:
           GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
-          gh api repos/ronelliott/homebrew-muzak/dispatches \
+          gh api repos/ronelliott/homebrew-public/dispatches \
             -f event_type=muzak-release \
             -f "client_payload[tag]=${{ github.ref_name }}"


### PR DESCRIPTION
The muzak formula moved into the consolidated public tap (ronelliott/homebrew-public, see its PR #1). This points the release notify job at the new tap repo; dispatch type event_type=muzak-release is unchanged.

**Before merging:** the repo secret \`TAP_GITHUB_TOKEN\` must be (re)scoped to have Contents:write on \`ronelliott/homebrew-public\` (it currently targets homebrew-muzak). Otherwise the dispatch step will 404 on the next release.

No merge — for review.

## Summary by Sourcery

CI:
- Update the release GitHub Actions workflow to dispatch repository events to ronelliott/homebrew-public and adjust related comments and naming.