### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Plays FLAC and WAV files, including tracks stored inside ZIP archives.
 
 ## Installation
 
+### Homebrew
+
+```sh
+brew tap ronelliott/public
+brew install ronelliott/public/muzak
+```
+
+### Go
+
 ```sh
 go install github.com/ronelliott/muzak/cmd@latest
 ```


### PR DESCRIPTION
Adds a Homebrew install option to the README, alongside the existing Go install/build steps. muzak ships from the public tap ronelliott/public (homebrew-public), so no token is needed.

```sh
brew tap ronelliott/public
brew install ronelliott/public/muzak
```

## Summary by Sourcery

Documentation:
- Add Homebrew tap and install commands to the README installation section.